### PR TITLE
Temperature is floating point not integer

### DIFF
--- a/bin/bwa_mqtt_bridge
+++ b/bin/bwa_mqtt_bridge
@@ -126,7 +126,7 @@ class MQTTBridge
         next @bwa.toggle_blower if value == 'toggle'
         @bwa.set_blower(value.to_i)
       when "spa/settemperature/set"
-        @bwa.set_temperature(value.to_i)
+        @bwa.set_temperature(value.to_f)
       end
     end
   end
@@ -186,10 +186,10 @@ class MQTTBridge
     subscribe("spa/temperaturerange/set")
 
     publish("spa/currenttemperature/$name", "Current temperature")
-    publish("spa/currenttemperature/$datatype", "integer")
+    publish("spa/currenttemperature/$datatype", "float")
 
     publish("spa/settemperature/$name", "Set Temperature")
-    publish("spa/settemperature/$datatype", "integer")
+    publish("spa/settemperature/$datatype", "float")
     publish("spa/settemperature/$settable", "true")
     subscribe("spa/settemperature/set")
 

--- a/lib/bwa/client.rb
+++ b/lib/bwa/client.rb
@@ -145,7 +145,7 @@ module BWA
     # low range is 50-80 for F, 10-26 for C (by 0.5)
     def set_temperature(desired)
       desired *= 2 if last_status && last_status.temperature_scale == :celsius || desired < 50
-      send_message("\x0a\xbf\x20#{desired.chr}")
+      send_message("\x0a\xbf\x20#{desired.round.chr}")
     end
 
     def set_time(hour, minute, twenty_four_hour_time = false)


### PR DESCRIPTION
Degrees Celsius varies in steps of 0.5, so declare the current and set temperatures as `float` not `integer`, and allow setting the temperature to a non-integer value.

Previously temperature was reported to homie as being `integer`, even though it sometimes was decimal (e.g., `38.5`). This causes problems for consumers that respect the datatype.

Previously it was not possible to set the temperature to a fractional value.

This fixes both of these issues.