### PR TITLE
Allow nil current temperature in C

### DIFF
--- a/lib/bwa/messages/status.rb
+++ b/lib/bwa/messages/status.rb
@@ -81,8 +81,8 @@ module BWA
         self.current_temperature = nil if self.current_temperature == 0xff
         self.set_temperature = data[20].ord
         if temperature_scale == :celsius
-          self.current_temperature /= 2.0
-          self.set_temperature /= 2.0
+          self.current_temperature /= 2.0 if self.current_temperature
+          self.set_temperature /= 2.0 if self.set_temperature
         end
       end
 


### PR DESCRIPTION
Thanks @richard-otto-obrien for this, spotted in https://github.com/ccutrer/balboa_worldwide_app/pull/20

If current temperature is not yet known, we store it as `nil`, but in C mode we then attempt to divide this by 2. Don't do that.

For consistency, treat set and current temperature the same, although at present set temperature can never be `nil`.