### PR TITLE
Automatically restart if bridge hangs

### DIFF
--- a/balboa_worldwide_app.gemspec
+++ b/balboa_worldwide_app.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mqtt', "~> 0.5.0"
   s.add_dependency 'net-telnet-rfc2217', "~> 0.0.3"
   s.add_dependency 'ccutrer-serialport', "~> 1.0.0"
+  s.add_dependency 'sd_notify', "~> 0.1.1"
 
   s.add_development_dependency 'byebug', "~> 9.0"
   s.add_development_dependency 'rake', "~> 13.0"

--- a/bin/bwa_mqtt_bridge
+++ b/bin/bwa_mqtt_bridge
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'mqtt'
+require 'sd_notify'
 
 require 'bwa/client'
 require 'bwa/discovery'
@@ -16,6 +17,9 @@ class MQTTBridge
     @things = Set.new
 
     publish_basic_attributes
+
+    # Tell systemd we've started up OK. Ignored if systemd not in use.
+    SdNotify.ready
 
     bwa_thread = Thread.new do
       loop do
@@ -88,6 +92,9 @@ class MQTTBridge
             (0..1).each do |i|
               publish_attribute("spa/aux#{i + 1}", message.lights[i]) if @bwa.last_control_configuration2&.aux&.[](i)
             end
+
+            # Tell systemd we are still alive and kicking. Ignored if systemd not in use.
+            SdNotify.watchdog
           end
         end
       end

--- a/contrib/bwa_mqtt_bridge.service
+++ b/contrib/bwa_mqtt_bridge.service
@@ -6,6 +6,9 @@ User=cody
 ExecStart=/usr/local/bin/bwa_mqtt_bridge mqtt://localhost/ /dev/ttyHotTub
 Restart=always
 RestartSec=3s
+Type=notify
+NotifyAccess=main
+WatchdogSec=60
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes corrupt data causes the data-processing thread to quit,
but the bridge keeps running. This means data is no longer transmitted
to the MQTT server, but systemd does not notice the problem.

This enhancement adds systemd support to `bwa_mqtt_bridge`, such that
the app notifies systemd when it starts successfully, and every time
it completes processing a status message. It then configures systemd
so that it restarts the app if it isn't notified for a while.

These changes have no effect if systemd is not in use (specifically,
if `NOTIFY_SOCKET` is not defined in the environment).