### PR TITLE
Add configurable logging

### DIFF
--- a/bin/bwa_mqtt_bridge
+++ b/bin/bwa_mqtt_bridge
@@ -3,8 +3,10 @@
 require 'mqtt'
 require 'sd_notify'
 
+require 'bwa/logger'
 require 'bwa/client'
 require 'bwa/discovery'
+require 'bwa/version'
 
 class MQTTBridge
   def initialize(mqtt_uri, bwa, device_id: "bwa", base_topic: "homie")
@@ -19,6 +21,7 @@ class MQTTBridge
     publish_basic_attributes
 
     # Tell systemd we've started up OK. Ignored if systemd not in use.
+    BWA.logger.warn "Balboa MQTT Bridge running (version #{BWA::VERSION})"
     SdNotify.ready
 
     bwa_thread = Thread.new do
@@ -27,7 +30,6 @@ class MQTTBridge
           message = @bwa.poll
           next if message.is_a?(BWA::Messages::Ready)
 
-          puts message.inspect unless message.is_a?(BWA::Messages::Status)
           case message
           when BWA::Messages::ControlConfiguration
             publish("spa/$type", message.model)
@@ -58,6 +60,7 @@ class MQTTBridge
 
             # allow a skew of 1 minute, since the seconds will always be off
             if diff > 1
+              BWA.logger.info "Spa time #{"%02d:%02d" % [message.hour, message.minute]}, actually #{"%02d:%02d" % [now.hour, now.min]}; correcting difference of #{diff} min"
               @bwa.set_time(now.hour, now.min, message.twenty_four_hour_time)
             end
             publish_attribute("spa/priming", message.priming)
@@ -101,7 +104,7 @@ class MQTTBridge
     end
 
     @mqtt.get do |topic, value|
-      puts "got #{value.inspect} at #{topic}"
+      BWA.logger.warn "from mqtt: #{value.inspect} at #{topic}"
       case topic[@base_topic.length + 1..-1]
       when "spa/heatingmode/set"
         next @bwa.toggle_heating_mode if value == 'toggle'
@@ -139,6 +142,7 @@ class MQTTBridge
   end
 
   def publish(topic, value)
+    BWA.logger.debug "  to mqtt: #{topic}: #{value}"
     @mqtt.publish("#{@base_topic}/#{topic}", value, true)
   end
 
@@ -267,6 +271,7 @@ mqtt_uri = ARGV.shift
 if ARGV.empty?
   spas = BWA::Discovery.discover
   if spas.empty?
+    BWA.logger.fatal "Could not find spa!"
     $stderr.puts "Could not find spa!"
     exit 1
   end

--- a/contrib/bwa_mqtt_bridge.service
+++ b/contrib/bwa_mqtt_bridge.service
@@ -4,6 +4,7 @@ Description=Balboa Spa MQTT Bridge
 [Service]
 User=cody
 ExecStart=/usr/local/bin/bwa_mqtt_bridge mqtt://localhost/ /dev/ttyHotTub
+Environment="LOG_LEVEL=WARN" "LOG_VERBOSITY=0"
 Restart=always
 RestartSec=3s
 Type=notify

--- a/lib/bwa/client.rb
+++ b/lib/bwa/client.rb
@@ -19,6 +19,7 @@ module BWA
         @io = CCutrer::SerialPort.new(uri.path, baud: 115200)
         @queue = []
       end
+      @src = 0x0a
       @buffer = ""
     end
 
@@ -42,7 +43,7 @@ module BWA
       end
 
       if message.is_a?(Messages::Ready) && (msg = @queue&.shift)
-        BWA.logger.debug "wrote: #{BWA.raw2str(msg)}" unless BWA.verbosity < 1 && msg[3..4] == "\xbf\x22"
+        BWA.logger.debug "wrote: #{BWA.raw2str(msg)}" unless BWA.verbosity < 1 && msg[3..4] == Messages::ControlConfigurationRequest::MESSAGE_TYPE
         @io.write(msg)
       end
       @last_status = message.dup if message.is_a?(Messages::Status)
@@ -61,37 +62,35 @@ module BWA
     end
 
     def send_message(message)
-      length = message.length + 2
-      full_message = "#{length.chr}#{message}".force_encoding(Encoding::ASCII_8BIT)
-      checksum = CRC.checksum(full_message)
-      full_message = "\x7e#{full_message}#{checksum.chr}\x7e".force_encoding(Encoding::ASCII_8BIT)
-      BWA.logger.info "  to spa: #{BWA.raw2str(message)}" unless BWA.verbosity < 1 && message[1..2] == "\xbf\x22"
+      message.src = @src
+      BWA.logger.info "  to spa: #{message.inspect}" unless BWA.verbosity < 1 && message.is_a?(Messages::ControlConfigurationRequest)
+      full_message = message.serialize
       if @queue
         @queue.push(full_message)
       else
-        BWA.logger.debug "wrote: #{BWA.raw2str(full_message)}" unless BWA.verbosity < 1 && message[3..4] == "\xbf\x22"
+        BWA.logger.debug "wrote: #{BWA.raw2str(full_message)}" unless BWA.verbosity < 1 && message.is_a?(Messages::ControlConfigurationRequest)
         @io.write(full_message)
       end
     end
 
     def request_configuration
-      send_message("\x0a\xbf\x04")
+      send_message(Messages::ConfigurationRequest.new)
     end
 
     def request_control_info2
-      send_message("\x0a\xbf\x22\x00\x00\x01")
+      send_message(Messages::ControlConfigurationRequest.new(2))
     end
 
     def request_control_info
-      send_message("\x0a\xbf\x22\x02\x00\x00")
+      send_message(Messages::ControlConfigurationRequest.new(1))
     end
 
     def request_filter_configuration
-      send_message("\x0a\xbf\x22\x01\x00\x00")
+      send_message(Messages::ControlConfigurationRequest.new(3))
     end
 
     def toggle_item(item)
-      send_message("\x0a\xbf\x11#{item.chr}\x00")
+      send_message(Messages::ToggleItem.new(item))
     end
 
     def toggle_pump(i)
@@ -103,11 +102,11 @@ module BWA
     end
 
     def toggle_mister
-      toggle_item(0x0e)
+      toggle_item(:mister)
     end
 
     def toggle_blower
-      toggle_item(0x0c)
+      toggle_item(:blower)
     end
 
     def set_pump(i, desired)
@@ -148,18 +147,16 @@ module BWA
     # low range is 50-80 for F, 10-26 for C (by 0.5)
     def set_temperature(desired)
       desired *= 2 if last_status && last_status.temperature_scale == :celsius || desired < 50
-      send_message("\x0a\xbf\x20#{desired.round.chr}")
+      send_message(Messages::SetTemperature.new(desired.round))
     end
 
     def set_time(hour, minute, twenty_four_hour_time = false)
-      hour |= 0x80 if twenty_four_hour_time
-      send_message("\x0a\xbf\x21".force_encoding(Encoding::ASCII_8BIT) + hour.chr + minute.chr)
+      send_message(Messages::SetTime.new(hour, minute, twenty_four_hour_time))
     end
 
     def set_temperature_scale(scale)
       raise ArgumentError, "scale must be :fahrenheit or :celsius" unless %I{fahrenheit :celsius}.include?(scale)
-      arg = scale == :fahrenheit ? 0 : 1
-      send_message("\x0a\xbf\x27\x01".force_encoding(Encoding::ASCII_8BIT) + arg.chr)
+      send_message(Messages::SetTemperatureScale.new(scale))
     end
 
     def toggle_temperature_range
@@ -173,7 +170,7 @@ module BWA
     end
 
     def toggle_heating_mode
-      toggle_item(0x51)
+      toggle_item(:heating_mode)
     end
 
     HEATING_MODES = %I{ready rest ready_in_rest}.freeze

--- a/lib/bwa/discovery.rb
+++ b/lib/bwa/discovery.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'bwa/logger'
 
 module BWA
   class Discovery
@@ -34,7 +35,7 @@ module BWA
           data, addr = socket.recvfrom(32)
           next unless data == 'Discovery: Who is out there?'
           ip = addr.last
-          puts "Advertising to #{ip}"
+          BWA.logger.info "Advertising to #{ip}"
           socket.sendmsg(msg, 0, Socket.sockaddr_in(addr[1], ip))
         end
       end

--- a/lib/bwa/logger.rb
+++ b/lib/bwa/logger.rb
@@ -1,0 +1,55 @@
+require 'logger'
+
+module BWA
+  # This module logs to stdout by default, or you can provide a logger as BWA.logger.
+  # If using default logger, set LOG_LEVEL in the environment to control logging.
+  #
+  # Log levels are:
+  #
+  # FATAL - fatal errors
+  # ERROR - handled errors
+  # WARN  - problems while parsing known messages
+  # INFO  - unrecognized messages
+  # DEBUG - all messages
+  #
+  # Certain very frequent messages are suppressed by default even in DEBUG mode.
+  # Set LOG_VERBOSITY to one of the following levels to see these:
+  #
+  # 0 - default
+  # 1 - show status messages
+  # 2 - show ready and nothing-to-send messages
+  #
+  class << self
+    attr_writer :logger, :verbosity
+
+    def logger
+      @logger ||= Logger.new(STDOUT).tap do |log|
+        STDOUT.sync = true
+        log.level = ENV.fetch("LOG_LEVEL","WARN")
+        log.formatter = proc do |severity, datetime, progname, msg|
+          "#{severity[0..0]}, #{msg2logstr(msg)}\n"
+        end
+      end
+    end
+
+    def verbosity
+      @verbosity ||= ENV.fetch("LOG_VERBOSITY", "0").to_i
+      @verbosity
+    end
+
+    def msg2logstr(msg)
+      case msg
+      when ::String
+        msg
+      when ::Exception
+        "#{ msg.message } (#{ msg.class })\n#{ msg.backtrace.join("\n") if msg.backtrace }"
+      else
+        msg.inspect
+      end
+    end
+
+    def raw2str(data)
+      data.unpack("H*").first.gsub!(/(..)/, "\\1 ").chop!
+    end
+  end
+end

--- a/lib/bwa/message.rb
+++ b/lib/bwa/message.rb
@@ -1,3 +1,4 @@
+require 'bwa/logger'
 require 'bwa/crc'
 
 module BWA
@@ -18,6 +19,26 @@ module BWA
       def inherited(klass)
         @messages ||= []
         @messages << klass
+      end
+
+      # Don't log messages of these types, even in DEBUG mode.
+      # They are very frequent and would swamp the logs.
+      def common_messages
+        @COMMON_MESSAGES ||= begin
+          msgs = []
+          msgs += [
+            Messages::Status::MESSAGE_TYPE,
+            "\xbf\xe1".force_encoding(Encoding::ASCII_8BIT),
+          ] unless BWA.verbosity >= 1
+          msgs += [
+            "\xbf\x00".force_encoding(Encoding::ASCII_8BIT),
+            "\xbf\xe1".force_encoding(Encoding::ASCII_8BIT),
+            Messages::Ready::MESSAGE_TYPE,
+            "\xbf\x07".force_encoding(Encoding::ASCII_8BIT),
+          ] unless BWA.verbosity >= 2
+          msgs
+        end
+        @COMMON_MESSAGES
       end
 
       def parse(data)
@@ -52,11 +73,11 @@ module BWA
           break
         end
 
-        puts "discarding invalid data prior to message #{data[0...offset].unpack('H*').first}" unless offset == 0
-        #puts "read #{data.slice(offset, length + 2).unpack('H*').first}"
+        message_type = data.slice(offset + 3, 2)
+        BWA.logger.debug "discarding invalid data prior to message #{BWA.raw2str(data[0...offset])}" unless offset == 0
+        BWA.logger.debug " read: #{BWA.raw2str(data.slice(offset, length + 2))}" unless common_messages.include?(message_type)
 
         src = data[offset + 2].ord
-        message_type = data.slice(offset + 3, 2)
         klass = @messages.find { |k| k::MESSAGE_TYPE == message_type }
 
 
@@ -73,6 +94,7 @@ module BWA
           end
           raise InvalidMessage.new("Unrecognized data length (#{length}) for message #{klass}", data) unless valid_length
         else
+          BWA.logger.info "Unrecognized message type #{BWA.raw2str(message_type)}: #{BWA.raw2str(data.slice(offset, length + 2))}"
           klass = Unrecognized
         end
 
@@ -80,6 +102,7 @@ module BWA
         message.parse(data.slice(offset + 5, length - 5))
         message.instance_variable_set(:@raw_data, data.slice(offset, length + 2))
         message.instance_variable_set(:@src, src)
+        BWA.logger.debug "from spa: #{message.inspect}" unless common_messages.include?(message_type)
         [message, offset + length + 2]
       end
 

--- a/lib/bwa/message.rb
+++ b/lib/bwa/message.rb
@@ -12,6 +12,8 @@ module BWA
   end
 
   class Message
+    attr_accessor :src
+
     class Unrecognized < Message
     end
 

--- a/lib/bwa/messages/configuration.rb
+++ b/lib/bwa/messages/configuration.rb
@@ -3,6 +3,10 @@ module BWA
     class Configuration < Message
       MESSAGE_TYPE = "\xbf\x94".force_encoding(Encoding::ASCII_8BIT)
       MESSAGE_LENGTH = 25
+
+      def inspect
+        "#<BWA::Messages::Configuration>"
+      end
     end
   end
 end

--- a/lib/bwa/messages/control_configuration.rb
+++ b/lib/bwa/messages/control_configuration.rb
@@ -7,6 +7,7 @@ module BWA
       attr_accessor :model, :version
 
       def initialize
+        super
         @model = ''
         @version = 0
       end

--- a/lib/bwa/messages/control_configuration_request.rb
+++ b/lib/bwa/messages/control_configuration_request.rb
@@ -7,14 +7,32 @@ module BWA
       attr_accessor :type
 
       def initialize(type = 1)
+        super()
         self.type = type
       end
 
       def parse(data)
-        self.type = data == "\x02\x00\x00" ? 1 : 2
+        self.type = case data
+          when "\x02\x00\x00"; 1
+          when "\x00\x00\x01"; 2
+          when "\x01\x00\x00"; 3
+          else 0
+        end
       end
 
+      def serialize
+        data = case type
+          when 1; "\x02\x00\x00"
+          when 2; "\x00\x00\x01"
+          when 3; "\x01\x00\x00"
+        else "\x00\x00\x00"
+        end
+        super(data)
+      end
 
+      def inspect
+        "#<BWA::Messages::ControlConfigurationRequest #{type}>"
+      end
     end
   end
 end

--- a/lib/bwa/messages/ready.rb
+++ b/lib/bwa/messages/ready.rb
@@ -3,6 +3,10 @@ module BWA
     class Ready < Message
       MESSAGE_TYPE = "\xbf\06".force_encoding(Encoding::ASCII_8BIT)
       MESSAGE_LENGTH = 0
+
+      def inspect
+        "#<BWA::Messages::Ready>"
+      end
     end
   end
 end

--- a/lib/bwa/messages/set_temperature.rb
+++ b/lib/bwa/messages/set_temperature.rb
@@ -7,6 +7,7 @@ module BWA
       attr_accessor :temperature
 
       def initialize(temperature = nil)
+        super()
         self.temperature = temperature
       end
 

--- a/lib/bwa/messages/set_temperature_scale.rb
+++ b/lib/bwa/messages/set_temperature_scale.rb
@@ -7,6 +7,7 @@ module BWA
       attr_accessor :scale
 
       def initialize(scale = nil)
+        super()
         self.scale = scale
       end
 

--- a/lib/bwa/messages/set_time.rb
+++ b/lib/bwa/messages/set_time.rb
@@ -7,6 +7,7 @@ module BWA
       attr_accessor :hour, :minute, :twenty_four_hour_time
 
       def initialize(hour = nil, minute = nil, twenty_four_hour_time = nil)
+        super()
         self.hour, self.minute, self.twenty_four_hour_time = hour, minute, twenty_four_hour_time
       end
 

--- a/lib/bwa/messages/toggle_item.rb
+++ b/lib/bwa/messages/toggle_item.rb
@@ -7,6 +7,7 @@ module BWA
       attr_accessor :item
 
       def initialize(item = nil)
+        super()
         self.item = item
       end
 
@@ -14,6 +15,8 @@ module BWA
         self.item = case data[0].ord
                       when 0x04; :pump1
                       when 0x05; :pump2
+                      when 0x0c; :blower
+                      when 0x0e; :mister
                       when 0x11; :light1
                       when 0x3c; :hold
                       when 0x50; :temperature_range
@@ -24,13 +27,20 @@ module BWA
 
       def serialize
         data = "\x00\x00"
-        data[0] = (case setting
-                     when :pump1; 0x04
-                     when :pump2; 0x05
-                     when :light1; 0x11
-                     when :temperature_range; 0x50
-                     when :heating_mode; 0x51
-                   end).chr
+        if item.is_a? Integer
+          data[0] = item.chr
+        else
+          data[0] = (case item
+                      when :pump1; 0x04
+                      when :pump2; 0x05
+                      when :blower; 0x0c
+                      when :mister; 0x0e
+                      when :light1; 0x11
+                      when :hold; 0x3c
+                      when :temperature_range; 0x50
+                      when :heating_mode; 0x51
+                    end).chr
+        end
         super(data)
       end
 

--- a/lib/bwa/proxy.rb
+++ b/lib/bwa/proxy.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'bwa/logger'
 require 'bwa/message'
 
 module BWA
@@ -44,9 +45,9 @@ module BWA
         leftover_data = leftover_data[(data_length + 2)..-1] || ''
         begin
           message = Message.parse(data)
-          puts "#{tag}: #{message.inspect}"
+          BWA.logger.info "#{tag}: #{message.inspect}"
         rescue InvalidMessage => e
-          puts "#{tag}: #{e}"
+          BWA.logger.info "#{tag}: #{e}"
         end
         socket2.send(data, 0)
       end

--- a/lib/bwa/server.rb
+++ b/lib/bwa/server.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'bwa/logger'
 require 'bwa/message'
 
 module BWA
@@ -26,7 +27,7 @@ module BWA
     end
 
     def run_client(socket)
-      puts "Received connection from #{socket.remote_address.inspect}"
+      BWA.logger.info "Received connection from #{socket.remote_address.inspect}"
 
       send_status(socket)
       loop do
@@ -35,8 +36,8 @@ module BWA
           break if data.empty?
           begin
             message = Message.parse(data)
-            puts message.raw_data.unpack("H*").first.scan(/[0-9a-f]{2}/).join(' ')
-            puts message.inspect
+            BWA.logger.info BWA.raw2str(message.raw_data)
+            BWA.logger.info message.inspect
 
             case message
             when Messages::ConfigurationRequest
@@ -64,8 +65,8 @@ module BWA
               end
             end
           rescue BWA::InvalidMessage => e
-            puts e.message
-            puts e.raw_data.unpack("H*").first.scan(/[0-9a-f]{2}/).join(' ')
+            BWA.logger.warn e.message
+            BWA.logger.warn BWA.raw2str(e.raw_data)
           end
         else
           send_status(socket)
@@ -74,7 +75,7 @@ module BWA
     end
 
     def send_status(socket)
-      puts "sending #{@status.inspect}"
+      BWA.logger.info "sending #{@status.inspect}"
       socket.send(@status.serialize, 0)
     end
 


### PR DESCRIPTION
*NOTE* This is a single commit on top of https://github.com/ccutrer/balboa_worldwide_app/pull/25 . 

Changes all the `puts` to proper Ruby logging, with level controlled by `LOG_LEVEL` environment variable, and additional control at debug level provided by `LOG_VERBOSITY`. See lib/bwa/logging.rb for configuration details.

Incidentally, use message objects for output rather than raw strings. This makes code and logs easier to read.

