### PR TITLE
Add SerialPort data bits, parity, and stop bits configuration

### DIFF
--- a/lib/bwa/client.rb
+++ b/lib/bwa/client.rb
@@ -48,7 +48,7 @@ module BWA
         @queue = []
       else
         require "ccutrer-serialport"
-        @io = CCutrer::SerialPort.new(uri.path, baud: 115_200)
+        @io = CCutrer::SerialPort.new(uri.path, baud: 115_200, data_bits: 8, parity: :none, stop_bits: 1)
         @queue = []
       end
       @src = 0x0a


### PR DESCRIPTION
When using the Raspberry Pi with an RS485 hat, the BWA service fails to start and times out due to missing SerialPort configuration. This change adds the necessary data_bits, parity, and stop_bits settings during initialization to ensure proper communication and prevent the service from failing.

The configuration parameters are according to the Wiki page:

> "The internal serial bus is [RS-485](https://en.wikipedia.org/wiki/RS-485) at 115200 baud, 8 bits per byte, no parity, 1 stop bit (115200/8-N-1)."