### PR TITLE
Adjust temperature step for target temperature based on temperature scale

### DIFF
--- a/exe/bwa_mqtt_bridge
+++ b/exe/bwa_mqtt_bridge
@@ -389,13 +389,14 @@ class MQTTBridge
     if @bwa.temperature_scale == :celsius
       @homie["spa"]["current-temperature"].format = 0..42
       @homie["spa"]["target-temperature"].format = 10..40
+      @homie["spa"]["target-temperature"].hass_number(icon: "mdi:thermometer", step: 0.5)
     else
       @homie["spa"]["current-temperature"].format = 32..108
       @homie["spa"]["target-temperature"].format = 50..106
+      @homie["spa"]["target-temperature"].hass_number(icon: "mdi:thermometer", step: 1)
     end
 
     @homie["spa"]["current-temperature"].hass_sensor(device_class: :temperature)
-    @homie["spa"]["target-temperature"].hass_number(icon: "mdi:thermometer", step: 0.5)
   end
 end
 

--- a/exe/bwa_mqtt_bridge
+++ b/exe/bwa_mqtt_bridge
@@ -395,7 +395,7 @@ class MQTTBridge
     end
 
     @homie["spa"]["current-temperature"].hass_sensor(device_class: :temperature)
-    @homie["spa"]["target-temperature"].hass_number(icon: "mdi:thermometer")
+    @homie["spa"]["target-temperature"].hass_number(icon: "mdi:thermometer", step: 0.5)
   end
 end
 


### PR DESCRIPTION
The spa's temperature control system operates in increments of 0.5 degrees, but the default step size in the code was set to 1 degree. This change adjusts the target-temperature step size to 0.5 for more precise control. With this change you can for example control the target temperature in Home Assistant with steps of 0.5 degrees.