### PR TITLE
Error handling for when connections are unreliable

### DIFF
--- a/lib/bwa/client.rb
+++ b/lib/bwa/client.rb
@@ -78,7 +78,7 @@ module BWA
 
             @io.wait_readable(5)
             retry
-          rescue Errno::ECONNRESET => e
+          rescue Errno::ECONNRESET
             BWA.logger.debug "ECONNRESET occured; retrying"
             @io.wait_readable(5)
             retry

--- a/lib/bwa/client.rb
+++ b/lib/bwa/client.rb
@@ -78,6 +78,10 @@ module BWA
 
             @io.wait_readable(5)
             retry
+          rescue Errno::ECONNRESET => e
+            BWA.logger.debug "ECONNRESET occured; retrying"
+            @io.wait_readable(5)
+            retry
           end
           next
         end

--- a/lib/bwa/client.rb
+++ b/lib/bwa/client.rb
@@ -76,7 +76,7 @@ module BWA
             eofs += 1
             raise if eofs == 5
 
-            @io.wait_readable
+            @io.wait_readable(5)
             retry
           end
           next


### PR DESCRIPTION
Original behavior could cause failure if the connection either drops or hangs (more pronounced if its directly connected to a remote host over less than reliable wi-fi). 

New behavior does two things:
- timeout for waiting for readable io (5 seconds)
- explicit error handling for ECONNRESET (just retry)